### PR TITLE
Fix multiline prompt

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -312,7 +312,7 @@ PINFO=(
     virtenv     $'%(1V.%F{yellow}%B\{%1v\} %b%f.)'
     date        $'%b%F{cyan}%D{%H:%M:%S}'
     user-host   $'%b%(2V.%S%(!.%F{red}%K{11} %m %f%k.%F{yellow} %n@%m %f)%s.%(!.%F{red}%m%f.%F{green}%n@%m))'
-    pipestatus  $'%(?.${pipestatuscolor}.%B%F{red})\u2514\u2500\u2562 $pipestatus_str \u255f${(r:$COLUMNS-8-$#pipestatus_str::\u2500:)}\u2518'
+    pipestatus  $'%(?.${pipestatuscolor}.%B%F{red})\u2514\u2500\u2562 $pipestatus_str \u255f${(r:$COLUMNS-7-$#pipestatus_str::\u2500:)}\u2518'
     pwd         $'%B%F{blue}< %~ >%f%b'
     jobs        $'%(1j. %B%F{yellow}(%j job%(2j.s.))%f%b.)'
     shlvl       $'%(2L. %F{magenta}#%L%f.)'
@@ -323,9 +323,7 @@ PINFO=(
     indent      $'%(2_:  :)%(3_:  :)%(4_:  :)%(5_:..:)'
 )
 
-PROMPT="$PINFO[pipestatus]
-$PINFO[virtenv]$PINFO[date] $PINFO[user-host] $PINFO[pwd]$PINFO[jobs]$PINFO[shlvl]
-$PINFO[histnum]$PINFO[vim]$PINFO[prompt]"
+PROMPT="$PINFO[pipestatus]$PINFO[virtenv]$PINFO[date] $PINFO[user-host] $PINFO[pwd]$PINFO[jobs]$PINFO[shlvl] $PINFO[histnum]$PINFO[vim]$PINFO[prompt]"
 
 PROMPT2="$PINFO[histnum]$PINFO[indent]$PINFO[vim]$PINFO[prompt2]"
 

--- a/.zshrc
+++ b/.zshrc
@@ -310,7 +310,7 @@ typeset -A PINFO
 
 PINFO=(
     virtenv     $'%(1V.%F{yellow}%B\{%1v\} %b%f.)'
-    date        $'%b%F{cyan}%D{%H:%M:%S}'
+    date        $'%b%F{cyan}%D{%T}'
     user-host   $'%b%(2V.%S%(!.%F{red}%K{11} %m %f%k.%F{yellow} %n@%m %f)%s.%(!.%F{red}%m%f.%F{green}%n@%m))'
     pipestatus  $'%(?.${pipestatuscolor}.%B%F{red})\u2514\u2500\u2562 $pipestatus_str \u255f${(r:$COLUMNS-7-$#pipestatus_str::\u2500:)}\u2518'
     pwd         $'%B%F{blue}< %~ >%f%b'
@@ -323,7 +323,15 @@ PINFO=(
     indent      $'%(2_:  :)%(3_:  :)%(4_:  :)%(5_:..:)'
 )
 
-PROMPT="$PINFO[pipestatus]$PINFO[virtenv]$PINFO[date] $PINFO[user-host] $PINFO[pwd]$PINFO[jobs]$PINFO[shlvl] $PINFO[histnum]$PINFO[vim]$PINFO[prompt]"
+top="$PINFO[pipestatus]"
+middle="$PINFO[virtenv]$PINFO[date] $PINFO[user-host] $PINFO[pwd]$PINFO[jobs]$PINFO[shlvl]"
+bottom="$PINFO[histnum]$PINFO[vim]$PINFO[prompt]"
+
+invisible='%([BSUbfksu]|([FBK]|){*})'
+
+middlecontent=${(S)middle//$~invisible}
+
+PROMPT="$top$middle\${(r:\$COLUMNS - \${#\${(%)middlecontent}} % \$COLUMNS:)}$bottom"
 
 PROMPT2="$PINFO[histnum]$PINFO[indent]$PINFO[vim]$PINFO[prompt2]"
 

--- a/.zshrc
+++ b/.zshrc
@@ -306,7 +306,9 @@ function zle-keymap-select {
 zle -N zle-keymap-select
 # }}}
 
-typeset -A PINFO
+() { # local scope
+local -A PINFO
+local top middle bottom invisible middlecontent
 
 PINFO=(
     virtenv     $'%(1V.%F{yellow}%B[%1v] %b%f.)'
@@ -331,13 +333,14 @@ invisible='%([BSUbfksu]|([FBK]|){*})'
 
 middlecontent=${(S)middle//$~invisible}
 
-PROMPT="$top$middle\${(r:\$COLUMNS - \${#\${(%)middlecontent}} % \$COLUMNS:)}$bottom"
+PROMPT="$top$middle\${(r,\$COLUMNS - \${#\${(%):-$middlecontent}} % \$COLUMNS,)}$bottom"
 
 PROMPT2="$PINFO[histnum]$PINFO[indent]$PINFO[vim]$PINFO[prompt2]"
 
 RPROMPT='${vcs_info_msg_0_}'
 
 RPROMPT2=$'<%(!.%F{red}.%F{green})%_%b%f%k'
+}
 
 # {{{ zle line editor initialization
 function zle-line-init {

--- a/.zshrc
+++ b/.zshrc
@@ -309,7 +309,7 @@ zle -N zle-keymap-select
 typeset -A PINFO
 
 PINFO=(
-    virtenv     $'%(1V.%F{yellow}%B\{%1v\} %b%f.)'
+    virtenv     $'%(1V.%F{yellow}%B[%1v] %b%f.)'
     date        $'%b%F{cyan}%*'
     user-host   $'%b%(2V.%S%(!.%F{red}%K{11} %m %f%k.%F{yellow} %n@%m %f)%s.%(!.%F{red}%m%f.%F{green}%n@%m))'
     pipestatus  $'%(?.${pipestatuscolor}.%B%F{red})\u2514\u2500\u2562 $pipestatus_str \u255f${(r:$COLUMNS-7-$#pipestatus_str::\u2500:)}\u2518'

--- a/.zshrc
+++ b/.zshrc
@@ -310,7 +310,7 @@ typeset -A PINFO
 
 PINFO=(
     virtenv     $'%(1V.%F{yellow}%B\{%1v\} %b%f.)'
-    date        $'%b%F{cyan}%D{%T}'
+    date        $'%b%F{cyan}%*'
     user-host   $'%b%(2V.%S%(!.%F{red}%K{11} %m %f%k.%F{yellow} %n@%m %f)%s.%(!.%F{red}%m%f.%F{green}%n@%m))'
     pipestatus  $'%(?.${pipestatuscolor}.%B%F{red})\u2514\u2500\u2562 $pipestatus_str \u255f${(r:$COLUMNS-7-$#pipestatus_str::\u2500:)}\u2518'
     pwd         $'%B%F{blue}< %~ >%f%b'


### PR DESCRIPTION
The previous multi-line prompt overwrote one or more output lines when the second line (the line before the explicit newline) had the exact same width as the terminal.